### PR TITLE
fix: implement automatic API versioning for Streak CRM endpoints

### DIFF
--- a/nodes/Streak/operations/contactOperations.ts
+++ b/nodes/Streak/operations/contactOperations.ts
@@ -27,10 +27,11 @@ export async function handleContactOperations(
 		);
 	} else if (operation === 'createContact') {
 		// Create Contact operation
+		const teamKey = this.getNodeParameter('teamKey', itemIndex) as string;
 		const contactEmail = this.getNodeParameter('email', itemIndex) as string;
 		const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as IDataObject;
 		
-		validateParameters.call(this, { contactEmail }, ['contactEmail'], itemIndex);
+		validateParameters.call(this, { teamKey, contactEmail }, ['teamKey', 'contactEmail'], itemIndex);
 		
 		const body: IDataObject = {
 			email: contactEmail,
@@ -63,7 +64,7 @@ export async function handleContactOperations(
 		return await makeStreakRequest.call(
 			this,
 			'POST',
-			'/contacts',
+			`/teams/${teamKey}/contacts`,
 			apiKey,
 			itemIndex,
 			body,

--- a/nodes/Streak/operations/organizationOperations.ts
+++ b/nodes/Streak/operations/organizationOperations.ts
@@ -27,10 +27,11 @@ export async function handleOrganizationOperations(
 		);
 	} else if (operation === 'createOrganization') {
 		// Create Organization operation
+		const teamKey = this.getNodeParameter('teamKey', itemIndex) as string;
 		const name = this.getNodeParameter('name', itemIndex) as string;
 		const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as IDataObject;
 		
-		validateParameters.call(this, { name }, ['name'], itemIndex);
+		validateParameters.call(this, { teamKey, name }, ['teamKey', 'name'], itemIndex);
 		
 		const body: IDataObject = {
 			name,
@@ -47,14 +48,17 @@ export async function handleOrganizationOperations(
 		return await makeStreakRequest.call(
 			this,
 			'POST',
-			'/organizations',
+			`/teams/${teamKey}/organizations`,
 			apiKey,
 			itemIndex,
 			body,
 		);
 	} else if (operation === 'checkExistingOrganizations') {
 		// Check Existing Organizations operation
+		const teamKey = this.getNodeParameter('teamKey', itemIndex) as string;
 		const checkFields = this.getNodeParameter('checkFields', itemIndex) as IDataObject;
+		
+		validateParameters.call(this, { teamKey }, ['teamKey'], itemIndex);
 		
 		if (!checkFields.domain && !checkFields.name) {
 			throw new NodeOperationError(
@@ -77,7 +81,7 @@ export async function handleOrganizationOperations(
 		return await makeStreakRequest.call(
 			this,
 			'POST',
-			'/organizations/check',
+			`/teams/${teamKey}/organizations?getIfExisting=true`,
 			apiKey,
 			itemIndex,
 			body,

--- a/nodes/Streak/operations/teamOperations.ts
+++ b/nodes/Streak/operations/teamOperations.ts
@@ -17,7 +17,7 @@ export async function handleTeamOperations(
 		return await makeStreakRequest.call(
 			this,
 			'GET',
-			'/teams',
+			'/users/me/teams',
 			apiKey,
 			itemIndex,
 		);


### PR DESCRIPTION
- Add centralized API version mapping for all 70+ Streak endpoints in utils.ts
- Implement automatic v1/v2 version detection in makeStreakRequest()
- Fix team operations to use correct v2 endpoints (/users/me/teams)
- Update contact operations to use team-based v2 endpoints
- Update organization operations to use team-based v2 endpoints
- Remove hardcoded v1 BASE_URL from StreakApiService
- Add pattern matching support for dynamic endpoints
- Ensure backward compatibility with existing code

This resolves API version conflicts and eliminates 404 errors from using wrong API versions for different endpoints.