### PR TITLE
this will match too early, so we'll just add v2s to the patterns for now

### DIFF
--- a/nodes/Streak/operations/utils.ts
+++ b/nodes/Streak/operations/utils.ts
@@ -11,26 +11,6 @@ import {
  * This ensures we use the correct API version for each endpoint
  */
 const ENDPOINT_API_VERSIONS: Record<string, 'v1' | 'v2'> = {
-	// v1 endpoints
-	'/users/me': 'v1',
-	'/users/': 'v1',
-	'/pipelines': 'v1',
-	'/pipelines/': 'v1',
-	'/boxes': 'v1',
-	'/boxes/': 'v1',
-	'/stages': 'v1',
-	'/stages/': 'v1',
-	'/fields': 'v1',
-	'/fields/': 'v1',
-	'/search': 'v1',
-	'/files': 'v1',
-	'/files/': 'v1',
-	'/threads': 'v1',
-	'/threads/': 'v1',
-	'/snippets': 'v1',
-	'/snippets/': 'v1',
-	'/newsfeed': 'v1',
-	
 	// v2 endpoints
 	'/users/me/teams': 'v2',
 	'/teams': 'v2',


### PR DESCRIPTION
The Create Box endpoint for example has pipelines in it, so the match happens too early and it exits before it hits the more specific regex, as more endpoints go to v2 we'll shift the priority