### PR TITLE
Fix issues with bulk box moving

### DIFF
--- a/nodes/Streak/services/StreakApiService.ts
+++ b/nodes/Streak/services/StreakApiService.ts
@@ -260,11 +260,16 @@ export class StreakApiService {
 		pipelineKey: string,
 		targetPipelineKey: string,
 		boxKeys: string[],
-	): Promise<IDataObject> {
-		return this.makeRequest(context, 'POST', `/pipelines/${pipelineKey}/boxes/batch`, apiKey, {
-			targetPipelineKey,
-			boxKeys,
-		}) as Promise<IDataObject>;
+	): Promise<IDataObject | IDataObject[]> {
+		// Transform the input to match Streak API v2 requirements
+		// API expects: [{ key: "boxKey", boxKey: "boxKey", pipelineKey: "targetPipelineKey" }, ...]
+		const requestBody = boxKeys.map(boxKey => ({
+			key: boxKey,
+			boxKey: boxKey,
+			pipelineKey: targetPipelineKey,
+		}));
+
+		return this.makeRequest(context, 'POST', `/pipelines/${pipelineKey}/boxes/batch`, apiKey, requestBody);
 	}
 
 	/**
@@ -338,7 +343,7 @@ export class StreakApiService {
 		method: IHttpRequestMethods,
 		endpoint: string,
 		apiKey: string,
-		body?: IDataObject,
+		body?: IDataObject | IDataObject[],
 		query?: IDataObject,
 		apiVersion?: 'v1' | 'v2',
 	): Promise<IDataObject | IDataObject[]> {
@@ -412,7 +417,7 @@ export class StreakApiService {
 		method: IHttpRequestMethods,
 		endpoint: string,
 		apiKey: string,
-		body?: IDataObject,
+		body?: IDataObject | IDataObject[],
 		query?: IDataObject,
 		apiVersion?: 'v1' | 'v2',
 	): Promise<IDataObject | IDataObject[]> {


### PR DESCRIPTION
This pull request updates the `StreakApiService` to support the new requirements of the Streak API v2, specifically for batch box moves between pipelines. The main changes involve transforming the request body to match the API's expected format and updating method signatures to handle arrays of data objects.

**Streak API v2 compatibility:**

* Updated the `moveBoxesToPipeline` method to transform the input and send an array of objects in the request body, matching the new Streak API v2 requirements. The method now returns a `Promise<IDataObject | IDataObject[]>` to handle responses that may be arrays.
* Modified the `makeRequest` method and its signature to accept and return either a single `IDataObject` or an array of `IDataObject`, supporting the new batch request format required by Streak API v2. [[1]](diffhunk://#diff-9884f9996c9b8049337f36eb5e30a944397ca43937c70f52113e9577480cd4d4L341-R346) [[2]](diffhunk://#diff-9884f9996c9b8049337f36eb5e30a944397ca43937c70f52113e9577480cd4d4L415-R420)