### PR TITLE
fix resourcelocator for stages in edit box

### DIFF
--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -162,7 +162,9 @@ export async function handleBoxOperations(
 		}
 
 		if (updateFields.stageKey) {
-			body.stageKey = updateFields.stageKey;
+			// Handle resourceLocator format for stageKey
+			const stageKeyParam = updateFields.stageKey as string | { mode: string; value: string };
+			body.stageKey = typeof stageKeyParam === 'string' ? stageKeyParam : stageKeyParam.value;
 		}
 
 		if (updateFields.assignedToTeamKeyOrUserKey) {


### PR DESCRIPTION
This pull request makes a focused update to the `handleBoxOperations` function to improve how `stageKey` values are handled. The change ensures that `stageKey` can now accept both plain strings and objects with a `value` property, increasing flexibility for different input formats.

- Improved input handling:
  * Updated the assignment of `body.stageKey` to support both string and object formats (with a `value` property), making the function more robust to varied input types.