### PR TITLE
fix issue with updating organizations

### DIFF
--- a/nodes/Streak/operations/organizationOperations.ts
+++ b/nodes/Streak/operations/organizationOperations.ts
@@ -42,7 +42,10 @@ export async function handleOrganizationOperations(
 		};
 
 		if (additionalFields.addresses) {
-			body.addresses = additionalFields.addresses;
+			// Addresses field must be an array - convert string to array if needed
+			body.addresses = Array.isArray(additionalFields.addresses) 
+				? additionalFields.addresses 
+				: [additionalFields.addresses];
 		}
 
 		if (additionalFields.domains && (additionalFields.domains as string[]).length > 0) {
@@ -74,7 +77,10 @@ export async function handleOrganizationOperations(
 		}
 
 		if (additionalFields.phoneNumbers) {
-			body.phoneNumbers = additionalFields.phoneNumbers;
+			// phoneNumbers field must be an array - convert string to array if needed
+			body.phoneNumbers = Array.isArray(additionalFields.phoneNumbers) 
+				? additionalFields.phoneNumbers 
+				: [additionalFields.phoneNumbers];
 		}
 
 		if (additionalFields.relationships) {
@@ -138,7 +144,10 @@ export async function handleOrganizationOperations(
 		const body: IDataObject = {};
 
 		if (updateFields.addresses) {
-			body.addresses = updateFields.addresses;
+			// Addresses field must be an array - convert string to array if needed
+			body.addresses = Array.isArray(updateFields.addresses) 
+				? updateFields.addresses 
+				: [updateFields.addresses];
 		}
 
 		if (updateFields.domains && (updateFields.domains as string[]).length > 0) {
@@ -174,7 +183,10 @@ export async function handleOrganizationOperations(
 		}
 
 		if (updateFields.phoneNumbers) {
-			body.phoneNumbers = updateFields.phoneNumbers;
+			// phoneNumbers field must be an array - convert string to array if needed
+			body.phoneNumbers = Array.isArray(updateFields.phoneNumbers) 
+				? updateFields.phoneNumbers 
+				: [updateFields.phoneNumbers];
 		}
 
 		if (updateFields.relationships) {

--- a/nodes/Streak/properties/organizationProperties.ts
+++ b/nodes/Streak/properties/organizationProperties.ts
@@ -152,9 +152,12 @@ export const organizationProperties: INodeProperties[] = [
 				displayName: 'Addresses',
 				name: 'addresses',
 				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+				},
 				default: '',
 				description:
-					'The only addresses associated with the organization will be the ones you include here, make sure to include any previously associated addresses as well as the new one(s)',
+					'Addresses associated with the organization. Can be a single address or multiple addresses. The Streak API replaces all existing addresses with the ones you provide (does not merge).',
 			},
 			{
 				displayName: 'Domains',
@@ -212,9 +215,12 @@ export const organizationProperties: INodeProperties[] = [
 				displayName: 'Phone Numbers',
 				name: 'phoneNumbers',
 				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+				},
 				default: '',
 				description:
-					'The only phone numbers associated with the organization will be the ones you include here, make sure to include any previously associated numbers as well as the new one(s)',
+					'Phone numbers associated with the organization. Can be a single number or multiple numbers. The Streak API replaces all existing numbers with the ones you provide (does not merge).',
 			},
 			{
 				displayName: 'Relationships',
@@ -251,9 +257,12 @@ export const organizationProperties: INodeProperties[] = [
 				displayName: 'Addresses',
 				name: 'addresses',
 				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+				},
 				default: '',
 				description:
-					'The only addresses associated with the organization will be the ones you include here, make sure to include any previously associated addresses as well as the new one(s)',
+					'Addresses associated with the organization. Can be a single address or multiple addresses. The Streak API replaces all existing addresses with the ones you provide (does not merge).',
 			},
 			{
 				displayName: 'Domains',
@@ -318,9 +327,12 @@ export const organizationProperties: INodeProperties[] = [
 				displayName: 'Phone Numbers',
 				name: 'phoneNumbers',
 				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+				},
 				default: '',
 				description:
-					'The only phone numbers associated with the organization will be the ones you include here, make sure to include any previously associated numbers as well as the new one(s)',
+					'Phone numbers associated with the organization. Can be a single number or multiple numbers. The Streak API replaces all existing numbers with the ones you provide (does not merge).',
 			},
 			{
 				displayName: 'Relationships',


### PR DESCRIPTION
This pull request improves how addresses and phone numbers are handled for organizations in the Streak integration. It ensures that both fields consistently support multiple values and updates the user interface and API handling to match. The changes help prevent errors when users provide single or multiple values and clarify the behavior in the UI.

**Support for multiple addresses and phone numbers:**

* In `organizationOperations.ts`, both the `addresses` and `phoneNumbers` fields are now always converted to arrays before being sent to the API, ensuring compatibility whether the user provides a single value or multiple values. [[1]](diffhunk://#diff-7197f77bdd903b138c759072ff7a7585f74558f5ad7b8672fde260aaef82fbdfL45-R48) [[2]](diffhunk://#diff-7197f77bdd903b138c759072ff7a7585f74558f5ad7b8672fde260aaef82fbdfL77-R83) [[3]](diffhunk://#diff-7197f77bdd903b138c759072ff7a7585f74558f5ad7b8672fde260aaef82fbdfL141-R150) [[4]](diffhunk://#diff-7197f77bdd903b138c759072ff7a7585f74558f5ad7b8672fde260aaef82fbdfL177-R189)

**User interface and property definition updates:**

* In `organizationProperties.ts`, the `addresses` and `phoneNumbers` fields are updated to support multiple values in both create and update operations by adding `typeOptions: { multipleValues: true }`. The descriptions are also clarified to explain that providing values will replace all existing entries, not merge with them. [[1]](diffhunk://#diff-aa4748e360bc31cd9bfc84f321ca6342279e8e148853fa0c7e65d764ec5ec540R155-R160) [[2]](diffhunk://#diff-aa4748e360bc31cd9bfc84f321ca6342279e8e148853fa0c7e65d764ec5ec540R218-R223) [[3]](diffhunk://#diff-aa4748e360bc31cd9bfc84f321ca6342279e8e148853fa0c7e65d764ec5ec540R260-R265) [[4]](diffhunk://#diff-aa4748e360bc31cd9bfc84f321ca6342279e8e148853fa0c7e65d764ec5ec540R330-R335)