### PR TITLE
Fix form-encoded endpoints for thread, snippet, and meeting creation

### DIFF
--- a/nodes/Streak/operations/meetingOperations.ts
+++ b/nodes/Streak/operations/meetingOperations.ts
@@ -1,5 +1,5 @@
-import { IExecuteFunctions, IDataObject, NodeOperationError  } from 'n8n-workflow';
-import { streakApiRequest, validateParameters, handlePagination } from './utils';
+import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
+import { streakApiRequest, streakApiFormRequest, validateParameters, handlePagination } from './utils';
 
 /**
  * Handle meeting-related operations for the Streak API
@@ -65,7 +65,7 @@ export async function handleMeetingOperations(
 			body.notes = additionalFields.notes;
 		}
 
-		return await streakApiRequest(this, 'POST', `/boxes/${boxKey}/meetings`, body);
+		return await streakApiFormRequest(this, 'POST', `/boxes/${boxKey}/meetings`, body);
 	} else if (operation === 'editMeeting') {
 		const meetingKey = this.getNodeParameter('meetingKey', itemIndex) as string;
 		const updateFields = this.getNodeParameter('updateFields', itemIndex, {}) as IDataObject;

--- a/nodes/Streak/operations/snippetOperations.ts
+++ b/nodes/Streak/operations/snippetOperations.ts
@@ -1,5 +1,5 @@
-import { IExecuteFunctions, IDataObject, NodeOperationError  } from 'n8n-workflow';
-import { streakApiRequest, validateParameters, handlePagination } from './utils';
+import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
+import { streakApiRequest, streakApiFormRequest, validateParameters, handlePagination } from './utils';
 
 /**
  * Handle snippet-related operations for the Streak API
@@ -37,7 +37,7 @@ export async function handleSnippetOperations(
 			itemIndex,
 		);
 
-		return await streakApiRequest(
+		return await streakApiFormRequest(
 			this,
 			'PUT',
 			'/snippets',

--- a/nodes/Streak/operations/threadOperations.ts
+++ b/nodes/Streak/operations/threadOperations.ts
@@ -1,5 +1,5 @@
-import { IExecuteFunctions, IDataObject, NodeOperationError  } from 'n8n-workflow';
-import { streakApiRequest, validateParameters, handlePagination } from './utils';
+import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
+import { streakApiRequest, streakApiFormRequest, validateParameters, handlePagination } from './utils';
 
 /**
  * Handle thread-related operations for the Streak API
@@ -60,7 +60,7 @@ export async function handleThreadOperations(
 			itemIndex,
 		);
 
-		return await streakApiRequest(
+		return await streakApiFormRequest(
 			this,
 			'PUT',
 			`/boxes/${boxKey}/threads`,


### PR DESCRIPTION
- Fixes thread, snippet, and meeting creation endpoints that require form-encoded request bodies instead of JSON
- Adds `streakApiFormRequest` helper and updates the three affected operations to use it

> **Note:** This PR should be merged after #26 (`feat/migrate-to-n8n-node-cli`) to avoid merge conflicts.