### PR TITLE
Add type-specific custom field inputs for Update Box operation

### DIFF
--- a/nodes/Streak/methods/loadOptions.ts
+++ b/nodes/Streak/methods/loadOptions.ts
@@ -176,7 +176,106 @@ export const loadOptions = {
 			return [];
 		}
 	},
+
+	async getTagValues(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+		try {
+			const fields = await getFieldsForCurrentBox(this);
+
+			// Read the sibling field key from the full parameter tree
+			let selectedFieldKey: string | undefined;
+			try {
+				const allParams = this.getCurrentNodeParameters() as Record<string, unknown>;
+				const uf = allParams?.updateFields as Record<string, unknown>;
+				const cf = uf?.customFields as Record<string, unknown>;
+				const entries = cf?.tagField as Array<{ key: { value: string } }>;
+				if (entries?.length) {
+					selectedFieldKey = entries[entries.length - 1]?.key?.value;
+				}
+			} catch {
+				// Fall back to showing all tags
+			}
+
+			const tagFields = fields.filter(
+				(f) => f.type === 'TAG' && f.tagSettings?.tags,
+			);
+			const needsPrefix = !selectedFieldKey && tagFields.length > 1;
+			const results: INodePropertyOptions[] = [];
+
+			for (const field of tagFields) {
+				if (selectedFieldKey && field.key !== selectedFieldKey) continue;
+				for (const tag of field.tagSettings!.tags) {
+					if (!tag.key) continue;
+					results.push({
+						name: needsPrefix ? `${field.name} \u2192 ${tag.tag}` : tag.tag,
+						value: tag.key,
+					});
+				}
+			}
+
+			return results;
+		} catch {
+			return [];
+		}
+	},
 };
+
+interface StreakField {
+	key: string;
+	name: string;
+	type: string;
+	dropdownSettings?: { items: Array<{ key: string; name: string }> };
+	tagSettings?: { tags: Array<{ key: string; tag: string }> };
+}
+
+async function getFieldsForCurrentBox(
+	context: ILoadOptionsFunctions,
+): Promise<StreakField[]> {
+	const boxKey = extractParamValue(context.getCurrentNodeParameter('boxKey'));
+	if (!boxKey) return [];
+
+	const box = (await streakApiRequest(context, 'GET', `/boxes/${boxKey}`)) as {
+		pipelineKey: string;
+	};
+	if (!box?.pipelineKey) return [];
+
+	return (await streakApiRequest(
+		context,
+		'GET',
+		`/pipelines/${box.pipelineKey}/fields`,
+	)) as unknown as StreakField[];
+}
+
+function applyFilter<T extends { key: string; name?: string }>(
+	items: T[],
+	filter: string | undefined,
+	getSearchableText: (item: T) => string,
+): T[] {
+	if (!filter) return items;
+	const filterLower = filter.toLowerCase();
+	return items.filter(
+		(item) => item && item.key && getSearchableText(item).toLowerCase().includes(filterLower),
+	);
+}
+
+async function getFieldOptionsByType(
+	this: ILoadOptionsFunctions,
+	fieldType: string,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	try {
+		const fields = await getFieldsForCurrentBox(this);
+		const typed = fields.filter((f) => f.type === fieldType);
+		const filtered = applyFilter(typed, filter, (f) => `${f.name || ''} ${f.key}`);
+
+		return {
+			results: filtered
+				.filter((f) => f.key)
+				.map((f) => ({ name: f.name || 'Unnamed Field', value: f.key })),
+		};
+	} catch {
+		return { results: [] };
+	}
+}
 
 export const listSearch = {
 	async getPipelineOptions(
@@ -301,55 +400,89 @@ export const listSearch = {
 		filter?: string,
 	): Promise<INodeListSearchResult> {
 		try {
-			// Get boxKey from the current node parameters to look up the pipeline
-			const boxKeyParam = this.getCurrentNodeParameter('boxKey');
-			let boxKey: string;
-			if (typeof boxKeyParam === 'string') {
-				boxKey = boxKeyParam;
-			} else if (boxKeyParam && typeof boxKeyParam === 'object') {
-				boxKey = (boxKeyParam as any).value || (boxKeyParam as any).id;
-			} else {
-				return { results: [] };
-			}
+			const fields = await getFieldsForCurrentBox(this);
+			// Exclude types that have their own dedicated dropdowns
+			const excludeTypes = ['FORMULA', 'CHECKBOX', 'DATE', 'DROPDOWN', 'TAG'];
+			const typed = fields.filter((f) => !excludeTypes.includes(f.type));
+			const filtered = applyFilter(typed, filter, (f) => `${f.name || ''} ${f.key}`);
 
-			if (!boxKey) {
-				return { results: [] };
-			}
-
-			// Fetch the box to get its pipelineKey
-			const box = (await streakApiRequest(this, 'GET', `/boxes/${boxKey}`)) as {
-				pipelineKey: string;
+			return {
+				results: filtered
+					.filter((f) => f.key)
+					.map((f) => ({
+						name: `${f.name || 'Unnamed Field'} (${f.type || 'unknown'})`,
+						value: f.key,
+					})),
 			};
+		} catch {
+			return { results: [] };
+		}
+	},
 
-			if (!box?.pipelineKey) {
-				return { results: [] };
+	async getCheckboxFieldOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		return getFieldOptionsByType.call(this, 'CHECKBOX', filter);
+	},
+
+	async getDateFieldOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		return getFieldOptionsByType.call(this, 'DATE', filter);
+	},
+
+	async getDropdownFieldOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		return getFieldOptionsByType.call(this, 'DROPDOWN', filter);
+	},
+
+	async getTagFieldOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		return getFieldOptionsByType.call(this, 'TAG', filter);
+	},
+
+	async getDropdownValueOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		try {
+			const fields = await getFieldsForCurrentBox(this);
+			const results: Array<{ name: string; value: string }> = [];
+
+			// Read the sibling field key from the full parameter tree
+			let selectedFieldKey: string | undefined;
+			try {
+				const allParams = this.getCurrentNodeParameters() as Record<string, unknown>;
+				const uf = allParams?.updateFields as Record<string, unknown>;
+				const cf = uf?.customFields as Record<string, unknown>;
+				const entries = cf?.dropdownField as Array<{ key: { value: string } }>;
+				if (entries?.length) {
+					selectedFieldKey = entries[entries.length - 1]?.key?.value;
+				}
+			} catch {
+				// Fall back to showing all options
 			}
 
-			// Fetch fields for the pipeline
-			const fields = (await streakApiRequest(
-				this,
-				'GET',
-				`/pipelines/${box.pipelineKey}/fields`,
-			)) as Array<{ key: string; name: string; type: string }>;
+			const dropdownFields = fields.filter(
+				(f) => f.type === 'DROPDOWN' && f.dropdownSettings?.items,
+			);
+			const needsPrefix = !selectedFieldKey && dropdownFields.length > 1;
 
-			let filteredFields = fields;
-			if (filter) {
-				const filterLower = filter.toLowerCase();
-				filteredFields = fields.filter(
-					(field) =>
-						field &&
-						field.key &&
-						((field.name || '').toLowerCase().includes(filterLower) ||
-							field.key.toLowerCase().includes(filterLower)),
-				);
+			for (const field of dropdownFields) {
+				if (selectedFieldKey && field.key !== selectedFieldKey) continue;
+				for (const item of field.dropdownSettings!.items) {
+					if (!item.key) continue;
+					const name = needsPrefix ? `${field.name} \u2192 ${item.name}` : item.name;
+					if (filter && !name.toLowerCase().includes(filter.toLowerCase())) continue;
+					results.push({ name, value: item.key });
+				}
 			}
-
-			const results = filteredFields
-				.filter((field) => field && field.key)
-				.map((field) => ({
-					name: `${field.name || 'Unnamed Field'} (${field.type || 'unknown'})`,
-					value: field.key || '',
-				}));
 
 			return { results };
 		} catch (error) {

--- a/nodes/Streak/methods/loadOptions.ts
+++ b/nodes/Streak/methods/loadOptions.ts
@@ -296,6 +296,67 @@ export const listSearch = {
 		}
 	},
 
+	async getFieldOptions(
+		this: ILoadOptionsFunctions,
+		filter?: string,
+	): Promise<INodeListSearchResult> {
+		try {
+			// Get boxKey from the current node parameters to look up the pipeline
+			const boxKeyParam = this.getCurrentNodeParameter('boxKey');
+			let boxKey: string;
+			if (typeof boxKeyParam === 'string') {
+				boxKey = boxKeyParam;
+			} else if (boxKeyParam && typeof boxKeyParam === 'object') {
+				boxKey = (boxKeyParam as any).value || (boxKeyParam as any).id;
+			} else {
+				return { results: [] };
+			}
+
+			if (!boxKey) {
+				return { results: [] };
+			}
+
+			// Fetch the box to get its pipelineKey
+			const box = (await streakApiRequest(this, 'GET', `/boxes/${boxKey}`)) as {
+				pipelineKey: string;
+			};
+
+			if (!box?.pipelineKey) {
+				return { results: [] };
+			}
+
+			// Fetch fields for the pipeline
+			const fields = (await streakApiRequest(
+				this,
+				'GET',
+				`/pipelines/${box.pipelineKey}/fields`,
+			)) as Array<{ key: string; name: string; type: string }>;
+
+			let filteredFields = fields;
+			if (filter) {
+				const filterLower = filter.toLowerCase();
+				filteredFields = fields.filter(
+					(field) =>
+						field &&
+						field.key &&
+						((field.name || '').toLowerCase().includes(filterLower) ||
+							field.key.toLowerCase().includes(filterLower)),
+				);
+			}
+
+			const results = filteredFields
+				.filter((field) => field && field.key)
+				.map((field) => ({
+					name: `${field.name || 'Unnamed Field'} (${field.type || 'unknown'})`,
+					value: field.key || '',
+				}));
+
+			return { results };
+		} catch (error) {
+			return { results: [] };
+		}
+	},
+
 	async getTeamSearchOptions(
 		this: ILoadOptionsFunctions,
 		filter?: string,

--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -1,5 +1,44 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError  } from 'n8n-workflow';
 import { streakApiRequest, validateParameters, handlePagination } from './utils';
+
+interface StreakFieldDef {
+	key: string;
+	name: string;
+	type: string;
+	dropdownSettings?: { items: Array<{ key: string; name: string }> };
+	tagSettings?: { tags: Array<{ key: string; tag: string }> };
+}
+
+async function getFieldDef(
+	context: IExecuteFunctions,
+	boxKey: string,
+	fieldKey: string,
+): Promise<StreakFieldDef | undefined> {
+	const box = (await streakApiRequest(context, 'GET', `/boxes/${boxKey}`)) as { pipelineKey: string };
+	if (!box?.pipelineKey) return undefined;
+	const fields = (await streakApiRequest(
+		context, 'GET', `/pipelines/${box.pipelineKey}/fields`,
+	)) as unknown as StreakFieldDef[];
+	return fields.find((f) => f.key === fieldKey);
+}
+
+async function resolveDropdownValue(
+	context: IExecuteFunctions,
+	boxKey: string,
+	fieldKey: string,
+	value: string,
+): Promise<string> {
+	const field = await getFieldDef(context, boxKey, fieldKey);
+	const items = field?.dropdownSettings?.items || [];
+	// If value already matches a key, return as-is
+	const byKey = items.find((i) => i.key === value);
+	if (byKey) return value;
+	// Otherwise try to match by display name
+	const byName = items.find((i) => i.name.toLowerCase() === value.toLowerCase());
+	return byName ? byName.key : value;
+}
+
+
 /**
  * Handle box-related operations for the Streak API
  */
@@ -199,14 +238,59 @@ export async function handleBoxOperations(
 
 		// Handle custom fields
 		const customFields = updateFields.customFields as IDataObject | undefined;
-		if (customFields?.field) {
-			const fieldEntries = customFields.field as IDataObject[];
+		if (customFields) {
 			const fields: IDataObject = {};
-			for (const entry of fieldEntries) {
-				const keyParam = entry.key as string | { mode: string; value: string };
-				const fieldKey = typeof keyParam === 'string' ? keyParam : keyParam.value;
-				fields[fieldKey] = entry.value;
+
+			const extractRlocValue = (param: unknown): string => {
+				if (typeof param === 'string') return param;
+				const obj = param as { mode: string; value: string };
+				return obj.value;
+			};
+
+			// Text / numeric fields
+			if (customFields.field) {
+				for (const entry of customFields.field as IDataObject[]) {
+					fields[extractRlocValue(entry.key)] = entry.value;
+				}
 			}
+
+			// Checkbox fields
+			if (customFields.checkboxField) {
+				for (const entry of customFields.checkboxField as IDataObject[]) {
+					fields[extractRlocValue(entry.key)] = entry.value;
+				}
+			}
+
+			// Date fields
+			if (customFields.dateField) {
+				for (const entry of customFields.dateField as IDataObject[]) {
+					fields[extractRlocValue(entry.key)] = new Date(entry.value as string).getTime();
+				}
+			}
+
+			// Dropdown fields — resolve display name to key if "By Value" mode
+			if (customFields.dropdownField) {
+				for (const entry of customFields.dropdownField as IDataObject[]) {
+					const fieldKey = extractRlocValue(entry.key);
+					let value = extractRlocValue(entry.value);
+
+					const valueParam = entry.value as { mode?: string; value: string } | string;
+					if (typeof valueParam === 'object' && valueParam.mode === 'id') {
+						value = await resolveDropdownValue(this, boxKey, fieldKey, value);
+					}
+
+					fields[fieldKey] = value;
+				}
+			}
+
+			// Tag fields — multiOptions returns an array of selected tag keys
+			if (customFields.tagField) {
+				for (const entry of customFields.tagField as IDataObject[]) {
+					const fieldKey = extractRlocValue(entry.key);
+					fields[fieldKey] = entry.value as string[];
+				}
+			}
+
 			body.fields = fields;
 		}
 

--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -196,6 +196,20 @@ export async function handleBoxOperations(
 		if (updateFields.assignedToTeamKeyOrUserKey) {
 			body.assignedToTeamKeyOrUserKey = updateFields.assignedToTeamKeyOrUserKey;
 		}
+
+		// Handle custom fields
+		const customFields = updateFields.customFields as IDataObject | undefined;
+		if (customFields?.field) {
+			const fieldEntries = customFields.field as IDataObject[];
+			const fields: IDataObject = {};
+			for (const entry of fieldEntries) {
+				const keyParam = entry.key as string | { mode: string; value: string };
+				const fieldKey = typeof keyParam === 'string' ? keyParam : keyParam.value;
+				fields[fieldKey] = entry.value;
+			}
+			body.fields = fields;
+		}
+
 		return await streakApiRequest(this, 'POST', `/boxes/${boxKey}`, body);
 	} else if (operation === 'deleteBox') {
 		// Delete Box operation

--- a/nodes/Streak/properties/boxProperties.ts
+++ b/nodes/Streak/properties/boxProperties.ts
@@ -266,6 +266,61 @@ export const boxProperties: INodeProperties[] = [
 		},
 		options: [
 			{
+				displayName: 'Assigned To (Team/User Key)',
+				name: 'assignedToTeamKeyOrUserKey',
+				type: 'string',
+				default: '',
+				description: 'New team or user key to assign the box to',
+			},
+			{
+				displayName: 'Custom Fields',
+				name: 'customFields',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				description: 'Custom field values to update on the box',
+				options: [
+					{
+						displayName: 'Field',
+						name: 'field',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'key',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The custom field to update',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getFieldOptions',
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. 1007',
+									},
+								],
+							},
+							{
+								displayName: 'Field Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The value to set for the custom field',
+							},
+						],
+					},
+				],
+			},
+			{
 				displayName: 'Name',
 				name: 'name',
 				type: 'string',
@@ -301,13 +356,6 @@ export const boxProperties: INodeProperties[] = [
 						placeholder: 'agxzfm1haWw...',
 					},
 				],
-			},
-			{
-				displayName: 'Assigned To (Team/User Key)',
-				name: 'assignedToTeamKeyOrUserKey',
-				type: 'string',
-				default: '',
-				description: 'New team or user key to assign the box to',
 			},
 		],
 	},

--- a/nodes/Streak/properties/boxProperties.ts
+++ b/nodes/Streak/properties/boxProperties.ts
@@ -283,7 +283,7 @@ export const boxProperties: INodeProperties[] = [
 				description: 'Custom field values to update on the box',
 				options: [
 					{
-						displayName: 'Field',
+						displayName: 'Text / Numeric Field',
 						name: 'field',
 						values: [
 							{
@@ -315,6 +315,169 @@ export const boxProperties: INodeProperties[] = [
 								type: 'string',
 								default: '',
 								description: 'The value to set for the custom field',
+							},
+						],
+					},
+					{
+						displayName: 'Checkbox Field',
+						name: 'checkboxField',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'key',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The checkbox field to update',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getCheckboxFieldOptions',
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. 1007',
+									},
+								],
+							},
+							{
+								displayName: 'Field Value',
+								name: 'value',
+								type: 'boolean',
+								default: false,
+								description: 'Whether the checkbox field should be checked',
+							},
+						],
+					},
+					{
+						displayName: 'Date Field',
+						name: 'dateField',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'key',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The date field to update',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getDateFieldOptions',
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. 1007',
+									},
+								],
+							},
+							{
+								displayName: 'Field Value',
+								name: 'value',
+								type: 'dateTime',
+								default: '',
+								description: 'The value to set for the date field',
+							},
+						],
+					},
+					{
+						displayName: 'Dropdown Field',
+						name: 'dropdownField',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'key',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The dropdown field to update',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getDropdownFieldOptions',
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. 1007',
+									},
+								],
+							},
+							{
+								displayName: 'Field Value',
+								name: 'value',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The dropdown option to set',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getDropdownValueOptions',
+										},
+									},
+									{
+										displayName: 'By Value',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. Option name or key',
+									},
+								],
+							},
+						],
+					},
+					{
+						displayName: 'Tag Field',
+						name: 'tagField',
+						values: [
+							{
+								displayName: 'Field',
+								name: 'key',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description: 'The tag field to update',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'getTagFieldOptions',
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+										placeholder: 'e.g. 1007',
+									},
+								],
+							},
+							{
+								displayName: 'Tag Names or IDs',
+								name: 'value',
+								type: 'multiOptions',
+								default: [],
+								description: 'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								typeOptions: {
+									loadOptionsMethod: 'getTagValues',
+								},
 							},
 						],
 					},


### PR DESCRIPTION
- Adds dedicated input types for custom fields in the Update Box operation: checkbox (boolean toggle), date (date picker), dropdown (filtered value list), and tag (multi-select)
- Dropdown and tag value pickers are filtered to show only options for the selected field
- Formula fields are excluded from the field picker since they are computed
- Includes display name → key resolution for dropdown/tag values entered via expression