### PR TITLE
Fix API auth, error handling, and StreakTrigger issues

### DIFF
--- a/nodes/Streak/StreakTrigger.node.ts
+++ b/nodes/Streak/StreakTrigger.node.ts
@@ -7,6 +7,7 @@ import type {
 	IWebhookFunctions,
 	IWebhookResponseData,
 } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
 
 import { streakApiRequest } from './operations/utils';
 
@@ -24,7 +25,7 @@ export class StreakTrigger implements INodeType {
 		},
 		usableAsTool: true,
 		inputs: [],
-		outputs: ['main'],
+		outputs: [NodeConnectionTypes.Main],
 		credentials: [
 			{
 				displayName: 'Streak API Key',
@@ -202,7 +203,10 @@ export class StreakTrigger implements INodeType {
 							`/teams/${teamKey}/webhooks`,
 						)) as IDataObject[];
 					}
-				} catch {
+				} catch (error: unknown) {
+					if (error instanceof Error) {
+						this.logger.warn(`Streak webhook check failed: ${error.message}`);
+					}
 					return false;
 				}
 
@@ -270,8 +274,14 @@ export class StreakTrigger implements INodeType {
 						'DELETE',
 						`/webhooks/${webhookKey}`,
 					);
-				} catch {
-					// Webhook may already be deleted, that's fine
+				} catch (error: unknown) {
+					// Webhook may already be deleted — log unexpected failures so operators
+					// know if the webhook was orphaned on Streak's side
+					if (error instanceof Error) {
+						this.logger.warn(
+							`Failed to delete Streak webhook ${webhookKey}: ${error.message}`,
+						);
+					}
 				}
 
 				delete webhookData.webhookKey;

--- a/nodes/Streak/operations/utils.ts
+++ b/nodes/Streak/operations/utils.ts
@@ -4,8 +4,10 @@ import {
 	ILoadOptionsFunctions,
 	IWebhookFunctions,
 	IDataObject,
+	NodeApiError,
 	NodeOperationError,
 	IHttpRequestMethods,
+	JsonObject,
 } from 'n8n-workflow';
 
 /**
@@ -80,20 +82,6 @@ export function getApiVersionForEndpoint(endpoint: string): 'v1' | 'v2' {
 }
 
 /**
- * Get the Streak API key from credentials
- */
-export async function getStreakApiKey(context: StreakApiContext): Promise<string> {
-	const credentials = await context.getCredentials('streakApi');
-	if (!credentials?.apiKey) {
-		throw new NodeOperationError(
-			context.getNode(),
-			'No API key provided. Please configure your Streak API credentials.',
-		);
-	}
-	return credentials.apiKey as string;
-}
-
-/**
  * Make a request to the Streak API. Works from any n8n context (execute, hook, webhook, loadOptions).
  * Accepts endpoint fragments (e.g. `/users/me`) and auto-detects the API version.
  */
@@ -105,7 +93,6 @@ export async function streakApiRequest(
 	query?: IDataObject,
 	apiVersion?: 'v1' | 'v2',
 ): Promise<IDataObject | IDataObject[]> {
-	const apiKey = await getStreakApiKey(context);
 	const version = apiVersion || getApiVersionForEndpoint(endpoint);
 	const url = `https://api.streak.com/api/${version}${endpoint}`;
 	const headers: IDataObject = {
@@ -115,23 +102,16 @@ export async function streakApiRequest(
 		headers['Content-Type'] = 'application/json';
 	}
 	try {
-		return (await context.helpers.httpRequest({
+		return (await context.helpers.httpRequestWithAuthentication.call(context, 'streakApi', {
 			method,
 			url,
 			headers,
-			auth: {
-				username: apiKey,
-				password: '',
-			},
 			qs: query,
 			body,
 			json: true,
 		})) as IDataObject | IDataObject[];
 	} catch (error) {
-		throw new NodeOperationError(
-			context.getNode(),
-			error instanceof Error ? error : new Error(`Streak API error on ${method} ${endpoint}`),
-		);
+		throw new NodeApiError(context.getNode(), error as JsonObject);
 	}
 }
 
@@ -147,7 +127,6 @@ export async function streakApiFormRequest(
 	query?: IDataObject,
 	apiVersion?: 'v1' | 'v2',
 ): Promise<IDataObject | IDataObject[]> {
-	const apiKey = await getStreakApiKey(context);
 	const version = apiVersion || getApiVersionForEndpoint(endpoint);
 	const url = `https://api.streak.com/api/${version}${endpoint}`;
 
@@ -163,26 +142,19 @@ export async function streakApiFormRequest(
 	}
 
 	try {
-		return (await context.helpers.httpRequest({
+		return (await context.helpers.httpRequestWithAuthentication.call(context, 'streakApi', {
 			method,
 			url,
 			headers: {
 				Accept: 'application/json',
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
-			auth: {
-				username: apiKey,
-				password: '',
-			},
 			qs: query,
 			body: formBody,
 			json: true,
 		})) as IDataObject | IDataObject[];
 	} catch (error) {
-		throw new NodeOperationError(
-			context.getNode(),
-			error instanceof Error ? error : new Error(`Streak API error on ${method} ${endpoint}`),
-		);
+		throw new NodeApiError(context.getNode(), error as JsonObject);
 	}
 }
 


### PR DESCRIPTION
Addresses all items from #25 except for the GitHub Actions publish workflow (which will be handled separately).

- **[HIGH] Use `httpRequestWithAuthentication()` instead of `httpRequest()`** — `streakApiRequest` and `streakApiFormRequest` now delegate credential injection to n8n via `httpRequestWithAuthentication('streakApi', ...)`, removing the manual `getStreakApiKey()` helper
- **[HIGH] StreakTrigger outputs use `NodeConnectionTypes.Main`** — replaced raw `'main'` string to match the regular Streak node
- **[MEDIUM] Use `NodeApiError` instead of `NodeOperationError`** — HTTP catch blocks now throw `NodeApiError` so status codes and response bodies are surfaced in the n8n UI
- **[MEDIUM] Log errors in `StreakTrigger.delete()`** — the empty `catch {}` now logs a warning so operators can detect orphaned webhooks
- **[MEDIUM] Log errors in `StreakTrigger.checkExists()`** — the silent fallback now logs a warning instead of silently returning `false`

Closes #25