### PR TITLE
Fix list operation pagination and improve pipeline field UX

### DIFF
--- a/nodes/Streak/methods/loadOptions.ts
+++ b/nodes/Streak/methods/loadOptions.ts
@@ -132,6 +132,46 @@ export const loadOptions = {
 		}
 	},
 
+	async getTeamMemberOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+		try {
+			const response = await streakApiRequest(this, 'GET', '/users/me/teams');
+			const teams = parseTeamsResponse(response);
+
+			const seen = new Set<string>();
+			const members: INodePropertyOptions[] = [];
+
+			for (const team of teams) {
+				if (!team.key) continue;
+				const teamData = (await streakApiRequest(
+					this,
+					'GET',
+					`/teams/${team.key}`,
+				)) as Record<string, unknown>;
+
+				const teamMembers = teamData.members as Array<{
+					email?: string;
+					displayName?: string;
+					fullName?: string;
+				}>;
+				if (!Array.isArray(teamMembers)) continue;
+
+				for (const member of teamMembers) {
+					if (!member.email || seen.has(member.email)) continue;
+					seen.add(member.email);
+					const label = member.fullName || member.displayName || member.email;
+					members.push({
+						name: label === member.email ? label : `${label} (${member.email})`,
+						value: member.email,
+					});
+				}
+			}
+
+			return members;
+		} catch {
+			return [];
+		}
+	},
+
 	async getStageOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 		try {
 			const pipelineKey = extractParamValue(this.getCurrentNodeParameter('pipelineKey'));

--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -191,8 +191,10 @@ export async function handleBoxOperations(
 			body.notes = additionalFields.notes;
 		}
 
-		if (additionalFields.assignedToTeamKeyOrUserKey) {
-			body.assignedToTeamKeyOrUserKey = additionalFields.assignedToTeamKeyOrUserKey;
+		if (additionalFields.assignedToSharingEntries) {
+			const entries = additionalFields.assignedToSharingEntries as string[];
+			const list = (Array.isArray(entries) ? entries : [entries]).filter((e) => !!e);
+			body.assignedToSharingEntries = JSON.stringify(list.map((email) => ({ email })));
 		}
 
 		return await streakApiRequest(this, 'POST', `/pipelines/${pipelineKey}/boxes`, body);
@@ -227,8 +229,10 @@ export async function handleBoxOperations(
 			body.stageKey = typeof stageKeyParam === 'string' ? stageKeyParam : stageKeyParam.value;
 		}
 
-		if (updateFields.assignedToTeamKeyOrUserKey) {
-			body.assignedToTeamKeyOrUserKey = updateFields.assignedToTeamKeyOrUserKey;
+		if (updateFields.assignedToSharingEntries) {
+			const entries = updateFields.assignedToSharingEntries as string[];
+			const list = (Array.isArray(entries) ? entries : [entries]).filter((e) => !!e);
+			body.assignedToSharingEntries = list.map((email) => ({ email }));
 		}
 
 		// Handle custom fields

--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -300,26 +300,67 @@ export async function handleBoxOperations(
 	} else if (operation === 'getTimeline') {
 		// Get Timeline operation
 		const boxKey = this.getNodeParameter('boxKey', itemIndex) as string;
+		const direction = this.getNodeParameter('direction', itemIndex, 'Descending') as string;
+		const timelineFilters = this.getNodeParameter('timelineFilters', itemIndex, []) as string[];
+		const startTimestampValue = this.getNodeParameter('startTimestamp', itemIndex, '') as string;
 		const returnAll = this.getNodeParameter('returnAll', itemIndex, false) as boolean;
 		const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
 
 		validateParameters.call(this, { boxKey }, ['boxKey'], itemIndex);
 
+		// Build query params — filters must be a bracketed string like [CALL_LOGS,COMMENTS]
+		const baseQuery: IDataObject = { direction };
+		if (timelineFilters.length > 0) {
+			baseQuery.filters = '[' + timelineFilters.join(',') + ']';
+		}
+		if (startTimestampValue) {
+			const ts = new Date(startTimestampValue).getTime();
+			if (!isNaN(ts)) {
+				baseQuery.startTimestamp = ts;
+			}
+		}
+
 		if (returnAll) {
-			return await handlePagination(
-				this,
-				`/boxes/${boxKey}/timeline`,
-				returnAll,
-				limit,
-			);
+			let allResults: IDataObject[] = [];
+			let nextPage: string | undefined;
+
+			do {
+				const query: IDataObject = nextPage
+					? { nextPageToken: nextPage }
+					: { ...baseQuery, limit: 100 };
+
+				const response = (await streakApiRequest(
+					this,
+					'GET',
+					`/boxes/${boxKey}/timeline`,
+					undefined,
+					query,
+				)) as IDataObject;
+
+				if (response?.entries && Array.isArray(response.entries)) {
+					allResults = [...allResults, ...(response.entries as IDataObject[])];
+				}
+
+				nextPage = response?.nextPage as string | undefined;
+			} while (nextPage);
+
+			return allResults;
 		} else {
-			return await streakApiRequest(
+			const query: IDataObject = { ...baseQuery, limit };
+
+			const response = (await streakApiRequest(
 				this,
 				'GET',
 				`/boxes/${boxKey}/timeline`,
 				undefined,
-				{ limit },
-			);
+				query,
+			)) as IDataObject;
+
+			if (response?.entries && Array.isArray(response.entries)) {
+				return response.entries as IDataObject[];
+			}
+
+			return Array.isArray(response) ? response : [response];
 		}
 	}
 

--- a/nodes/Streak/operations/boxOperations.ts
+++ b/nodes/Streak/operations/boxOperations.ts
@@ -64,6 +64,7 @@ export async function handleBoxOperations(
 				: stageKeyFilterParam?.value || '';
 		const searchQuery = this.getNodeParameter('searchQuery', itemIndex, '') as string;
 		const trimmedSearchQuery = searchQuery?.trim();
+		const sortBy = this.getNodeParameter('sortBy', itemIndex, 'lastUpdatedTimestamp') as string;
 		const returnAll = this.getNodeParameter('returnAll', itemIndex, false) as boolean;
 		const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
 
@@ -111,29 +112,23 @@ export async function handleBoxOperations(
 
 			return results;
 		} else {
-			// No search query - use regular list boxes endpoint
-			const queryParams: IDataObject = { limit };
+			// No search query - use regular list boxes endpoint (v1 supports page/limit/sortBy)
+			const queryParams: IDataObject = {};
 			if (stageKeyFilter) {
 				queryParams.stageKey = stageKeyFilter;
 			}
-
-			if (returnAll) {
-				return await handlePagination(
-					this,
-					`/pipelines/${pipelineKey}/boxes`,
-					returnAll,
-					limit,
-					queryParams,
-				);
-			} else {
-				return await streakApiRequest(
-					this,
-					'GET',
-					`/pipelines/${pipelineKey}/boxes`,
-					undefined,
-					queryParams,
-				);
+			if (sortBy) {
+				queryParams.sortBy = sortBy;
 			}
+
+			return await handlePagination(
+				this,
+				`/pipelines/${pipelineKey}/boxes`,
+				returnAll,
+				returnAll ? 100 : limit,
+				queryParams,
+				'v1',
+			);
 		}
 	} else if (operation === 'getBox') {
 		// Get Box operation

--- a/nodes/Streak/operations/commentOperations.ts
+++ b/nodes/Streak/operations/commentOperations.ts
@@ -1,5 +1,5 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError  } from 'n8n-workflow';
-import { streakApiRequest, validateParameters, handlePagination } from './utils';
+import { streakApiRequest, validateParameters } from './utils';
 
 /**
  * Handle comment-related operations for the Streak API
@@ -19,13 +19,25 @@ export async function handleCommentOperations(
 
 		validateParameters.call(this, { boxKey }, ['boxKey'], itemIndex);
 
-		return await handlePagination(
+		// v2 returns { hasNextPage, results } with no pagination params
+		const response = (await streakApiRequest(
 			this,
+			'GET',
 			`/boxes/${boxKey}/comments`,
-			returnAll,
-			returnAll ? 100 : limit,
-			{},
-		);
+		)) as IDataObject;
+
+		let results: IDataObject[] = [];
+		if (response?.results && Array.isArray(response.results)) {
+			results = response.results as IDataObject[];
+		} else if (Array.isArray(response)) {
+			results = response;
+		}
+
+		if (!returnAll && results.length > limit) {
+			return results.slice(0, limit);
+		}
+
+		return results;
 	} else if (operation === 'getComment') {
 		const commentKey = this.getNodeParameter('commentKey', itemIndex) as string;
 

--- a/nodes/Streak/operations/meetingOperations.ts
+++ b/nodes/Streak/operations/meetingOperations.ts
@@ -1,5 +1,5 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
-import { streakApiRequest, streakApiFormRequest, validateParameters, handlePagination } from './utils';
+import { streakApiRequest, streakApiFormRequest, validateParameters } from './utils';
 
 /**
  * Handle meeting-related operations for the Streak API
@@ -19,13 +19,25 @@ export async function handleMeetingOperations(
 
 		validateParameters.call(this, { boxKey }, ['boxKey'], itemIndex);
 
-		return await handlePagination(
+		// v2 returns all meetings with no pagination params
+		const response = (await streakApiRequest(
 			this,
+			'GET',
 			`/boxes/${boxKey}/meetings`,
-			returnAll,
-			returnAll ? 100 : limit,
-			{},
-		);
+		)) as IDataObject;
+
+		let results: IDataObject[] = [];
+		if (response?.results && Array.isArray(response.results)) {
+			results = response.results as IDataObject[];
+		} else if (Array.isArray(response)) {
+			results = response;
+		}
+
+		if (!returnAll && results.length > limit) {
+			return results.slice(0, limit);
+		}
+
+		return results;
 	} else if (operation === 'getMeeting') {
 		const meetingKey = this.getNodeParameter('meetingKey', itemIndex) as string;
 

--- a/nodes/Streak/properties/boxProperties.ts
+++ b/nodes/Streak/properties/boxProperties.ts
@@ -173,6 +173,31 @@ export const boxProperties: INodeProperties[] = [
 		},
 	},
 
+	// Sort By (for listBoxes)
+	{
+		displayName: 'Sort By',
+		name: 'sortBy',
+		type: 'options',
+		default: 'lastUpdatedTimestamp',
+		description: 'What order to sort the boxes by (descending)',
+		options: [
+			{
+				name: 'Last Updated',
+				value: 'lastUpdatedTimestamp',
+			},
+			{
+				name: 'Creation Date',
+				value: 'creationTimestamp',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['box'],
+				operation: ['listBoxes'],
+			},
+		},
+	},
+
 	// Box Name (for createBox)
 	{
 		displayName: 'Box Name',

--- a/nodes/Streak/properties/boxProperties.ts
+++ b/nodes/Streak/properties/boxProperties.ts
@@ -75,6 +75,71 @@ export const boxProperties: INodeProperties[] = [
 		},
 	},
 
+	// Timeline Filters (for getTimeline)
+	{
+		displayName: 'Filters',
+		name: 'timelineFilters',
+		type: 'multiOptions',
+		default: [],
+		description: 'Entity types to include in the timeline. If none are selected, all types are included.',
+		options: [
+			{ name: 'Box Creation/Move', value: 'NEWSFEED_BOX_CREATION_MOVE' },
+			{ name: 'Box Edit', value: 'NEWSFEED_BOX_EDIT' },
+			{ name: 'Call Logs', value: 'CALL_LOGS' },
+			{ name: 'Comments', value: 'COMMENTS' },
+			{ name: 'Emails', value: 'EMAILS' },
+			{ name: 'Files', value: 'FILES' },
+			{ name: 'Hangouts Chat', value: 'HANGOUTS_CHAT' },
+			{ name: 'Meeting Notes', value: 'MEETING_NOTES' },
+		],
+		displayOptions: {
+			show: {
+				resource: ['box'],
+				operation: ['getTimeline'],
+			},
+		},
+	},
+
+	// Timeline Start Timestamp (for getTimeline)
+	{
+		displayName: 'Start Timestamp',
+		name: 'startTimestamp',
+		type: 'dateTime',
+		default: '',
+		description: 'Return entries starting from this point. Descending returns entries before this time, Ascending returns entries after. Leave empty for no filter.',
+		displayOptions: {
+			show: {
+				resource: ['box'],
+				operation: ['getTimeline'],
+			},
+		},
+	},
+
+	// Timeline Direction (for getTimeline)
+	{
+		displayName: 'Direction',
+		name: 'direction',
+		type: 'options',
+		default: 'Descending',
+		description: 'Descending returns newest first (entries before Start Timestamp). Ascending returns oldest first (entries after Start Timestamp).',
+		options: [
+			{
+				name: 'Descending',
+				value: 'Descending',
+			},
+			{
+				name: 'Ascending',
+				value: 'Ascending',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['box'],
+				operation: ['getTimeline'],
+			},
+		},
+	},
+
 	// Box Keys (for getMultipleBoxes)
 	{
 		displayName: 'Box Keys',

--- a/nodes/Streak/properties/boxProperties.ts
+++ b/nodes/Streak/properties/boxProperties.ts
@@ -332,11 +332,15 @@ export const boxProperties: INodeProperties[] = [
 				description: 'Notes to add to the box',
 			},
 			{
-				displayName: 'Assigned To (Team/User Key)',
-				name: 'assignedToTeamKeyOrUserKey',
-				type: 'string',
-				default: '',
-				description: 'Team or user key to assign the box to',
+				displayName: 'Assigned To (Emails)',
+				name: 'assignedToSharingEntries',
+				type: 'multiOptions',
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description: 'Select team members or use an expression to set emails programmatically. Assigned users must have access to the pipeline. Replaces all current assignees — include existing ones to keep them.',
+				typeOptions: {
+					loadOptionsMethod: 'getTeamMemberOptions',
+				},
 			},
 		],
 	},
@@ -356,11 +360,15 @@ export const boxProperties: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Assigned To (Team/User Key)',
-				name: 'assignedToTeamKeyOrUserKey',
-				type: 'string',
-				default: '',
-				description: 'New team or user key to assign the box to',
+				displayName: 'Assigned To (Emails)',
+				name: 'assignedToSharingEntries',
+				type: 'multiOptions',
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description: 'Select team members or use an expression to set emails programmatically. Assigned users must have access to the pipeline. Replaces all current assignees — include existing ones to keep them.',
+				typeOptions: {
+					loadOptionsMethod: 'getTeamMemberOptions',
+				},
 			},
 			{
 				displayName: 'Custom Fields',

--- a/nodes/Streak/properties/commentProperties.ts
+++ b/nodes/Streak/properties/commentProperties.ts
@@ -63,14 +63,29 @@ export const commentProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
-		displayName: 'Pipeline Key',
+		displayName: 'Pipeline',
 		name: 'pipelineKey',
-		type: 'string',
-		default: '',
-		required: true,
-		description: 'The key of the pipeline containing the box',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'getPipelineOptions',
+				},
+			},
+			{
+				displayName: 'By ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'agxzfm1haWw...',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['comment'],

--- a/nodes/Streak/properties/fieldProperties.ts
+++ b/nodes/Streak/properties/fieldProperties.ts
@@ -97,14 +97,13 @@ export const fieldProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
 		displayName: 'Pipeline',
 		name: 'pipelineKey',
 		type: 'resourceLocator',
 		default: { mode: 'list', value: '' },
-		required: true,
-		description: 'The pipeline containing the box',
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
 		modes: [
 			{
 				displayName: 'From List',

--- a/nodes/Streak/properties/fileProperties.ts
+++ b/nodes/Streak/properties/fileProperties.ts
@@ -58,14 +58,29 @@ export const fileProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
-		displayName: 'Pipeline Key',
+		displayName: 'Pipeline',
 		name: 'pipelineKey',
-		type: 'string',
-		default: '',
-		required: true,
-		description: 'The key of the pipeline containing the box',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'getPipelineOptions',
+				},
+			},
+			{
+				displayName: 'By ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'agxzfm1haWw...',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['file'],

--- a/nodes/Streak/properties/meetingProperties.ts
+++ b/nodes/Streak/properties/meetingProperties.ts
@@ -63,14 +63,29 @@ export const meetingProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
-		displayName: 'Pipeline Key',
+		displayName: 'Pipeline',
 		name: 'pipelineKey',
-		type: 'string',
-		default: '',
-		required: true,
-		description: 'The key of the pipeline containing the box',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'getPipelineOptions',
+				},
+			},
+			{
+				displayName: 'By ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'agxzfm1haWw...',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['meeting'],

--- a/nodes/Streak/properties/taskProperties.ts
+++ b/nodes/Streak/properties/taskProperties.ts
@@ -164,14 +164,15 @@ export const taskProperties: INodeProperties[] = [
 				description: 'The due date of the task',
 			},
 			{
-				displayName: 'Assignee Emails',
+				displayName: 'Assigned To (Emails)',
 				name: 'assignees',
-				type: 'string',
+				type: 'multiOptions',
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description: 'Select team members or use an expression to set emails programmatically',
 				typeOptions: {
-					multipleValues: true,
+					loadOptionsMethod: 'getTeamMemberOptions',
 				},
-				default: '',
-				description: 'Email addresses of assignees',
 			},
 		],
 	},
@@ -191,14 +192,15 @@ export const taskProperties: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Assignees',
+				displayName: 'Assigned To (Emails)',
 				name: 'assignees',
-				type: 'string',
+				type: 'multiOptions',
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description: 'Select team members or use an expression to set emails programmatically',
 				typeOptions: {
-					multipleValues: true,
+					loadOptionsMethod: 'getTeamMemberOptions',
 				},
-				default: '',
-				description: 'Email addresses of assignees',
 			},
 			{
 				displayName: 'Completed',

--- a/nodes/Streak/properties/taskProperties.ts
+++ b/nodes/Streak/properties/taskProperties.ts
@@ -63,14 +63,29 @@ export const taskProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
-		displayName: 'Pipeline Key',
+		displayName: 'Pipeline',
 		name: 'pipelineKey',
-		type: 'string',
-		default: '',
-		required: true,
-		description: 'The key of the pipeline containing the box',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'getPipelineOptions',
+				},
+			},
+			{
+				displayName: 'By ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'agxzfm1haWw...',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['task'],

--- a/nodes/Streak/properties/threadProperties.ts
+++ b/nodes/Streak/properties/threadProperties.ts
@@ -63,14 +63,29 @@ export const threadProperties: INodeProperties[] = [
 		},
 	},
 
-	// Pipeline Key (required for box dependency)
+	// Pipeline (optional, used to populate the box dropdown)
 	{
-		displayName: 'Pipeline Key',
+		displayName: 'Pipeline',
 		name: 'pipelineKey',
-		type: 'string',
-		default: '',
-		required: true,
-		description: 'The key of the pipeline containing the box',
+		type: 'resourceLocator',
+		default: { mode: 'list', value: '' },
+		description: 'Optional. Select a pipeline to populate the Box dropdown below. Not needed if entering a Box ID directly.',
+		modes: [
+			{
+				displayName: 'From List',
+				name: 'list',
+				type: 'list',
+				typeOptions: {
+					searchListMethod: 'getPipelineOptions',
+				},
+			},
+			{
+				displayName: 'By ID',
+				name: 'id',
+				type: 'string',
+				placeholder: 'agxzfm1haWw...',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['thread'],


### PR DESCRIPTION
- Fix "Return All" / "Limit" for List Boxes in Pipeline by using the correct API version (v1 instead of v2) and add a Sort By option (`lastUpdatedTimestamp`, `creationTimestamp`)
- Fix Get Timeline to use cursor-based pagination (`nextPageToken`/`nextPage`/`entries`) matching the v2 API response format, and add Filters, Direction, and Start Timestamp query parameters
- Fix List Comments and List Meetings to correctly extract results from the v2 wrapper response (`{ results, hasNextPage }`)
- Make the Pipeline field optional (with a proper resource locator dropdown) across all box-dependent resources (Comment, Thread, Meeting, File, Task, Field) — it's only needed when selecting a box from the list, not when entering a Box ID directly
- Fix Assigned To field on Create/Update Box (wrong API field name and format) and upgrade all assignee fields (Box + Task) to a team member dropdown populated from the Streak API